### PR TITLE
feat: add url scheme and installed bank apps opening

### DIFF
--- a/Sources/FlizpaySDK/FlizpaySDK.swift
+++ b/Sources/FlizpaySDK/FlizpaySDK.swift
@@ -12,12 +12,14 @@ public class FlizpaySDK {
     ///   - presentingVC: The `UIViewController` from which to present the payment web view.
     ///   - token: The JWT token fetched by the host app.
     ///   - amount: The transaction amount.
+    ///   - urlScheme: The application url scheme.
     ///   - transactionService: Inject the transaction service, for mockup purposes
     ///   - onFailure: Optional completion closure if you want to handle errors (e.g., show alerts).
     public static func initiatePayment(
         from presentingVC: UIViewController,
         token: String,
         amount: String,
+        urlScheme: String,
         transactionService: TransactionService? = nil,
         onFailure: ((Error) -> Void)? = nil
     ) {
@@ -33,6 +35,7 @@ public class FlizpaySDK {
                     FlizpayWebView().present(
                         from: presentingVC,
                         redirectUrl: redirectUrl,
+                        urlScheme: urlScheme,
                         jwt: token
                     )
                 case .failure(let error):


### PR DESCRIPTION
- add mechanism to natively open installed bank application for no credentials bank;

- add application URL scheme to initiatePayment arguments. URL scheme will be passed to secure.flizpay.de with search parameters to ensure that after redirecting user to installed application (e.g Revolut), it will redirect back to application and not to browser window;