### PR TITLE
Feat/release-on-cocoapods

### DIFF
--- a/FlizpaySDK.podspec
+++ b/FlizpaySDK.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name             = 'FlizpaySDK'
+  s.version          = '0.2.0'
+  s.summary          = 'Flizpay iOS SDK'
+  s.description      = 'iOS SDK for integrating Flizpay payment services'
+  s.homepage         = 'https://github.com/Flizpay/flizpay-ios'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Flizpay' => 'carlos.cunha@flizpay.de' }
+  s.source           = { :git => 'https://github.com/Flizpay/flizpay-ios.git', :tag => s.version.to_s }
+  s.ios.deployment_target = '13.0'
+  s.swift_version = '5.0'
+  s.source_files = 'Sources/FlizpaySDK/**/*'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .target(
             name: "FlizpaySDK",
             cSettings: [
+                // Explicitly specifying architectures for Simulators compatibility
                 .unsafeFlags(["-arch", "x86_64", "-arch", "arm64"])
             ]),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,10 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(
-            name: "FlizpaySDK"),
+            name: "FlizpaySDK",
+            cSettings: [
+                .unsafeFlags(["-arch", "x86_64", "-arch", "arm64"])
+            ]),
         .testTarget(
             name: "FlizpaySDKTests",
             dependencies: ["FlizpaySDK"]),

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Platform](https://img.shields.io/badge/platform-iOS-blue)](https://developer.apple.com/ios/)
 [![Swift](https://img.shields.io/badge/swift-5-orange)](https://swift.org/)
 [![SPM Compatible](https://img.shields.io/badge/SPM-compatible-brightgreen)](https://swift.org/package-manager/)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/FlizpaySDK.svg)](https://cocoapods.org/pods/FlizpaySDK)
 [![Version](https://img.shields.io/github/v/tag/Flizpay/flizpay-ios)](https://github.com/Flizpay/flizpay-ios/releases)
 [![iOS SDK Tests](https://github.com/Flizpay/flizpay-ios/actions/workflows/run-tests.yml/badge.svg)](https://github.com/Flizpay/flizpay-ios/actions/workflows/run-tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/Flizpay/flizpay-ios/badge.svg?branch=main)](https://coveralls.io/github/Flizpay/flizpay-ios?branch=main)
@@ -20,7 +21,33 @@ Get started with our 📚 [integration guide](https://www.docs.flizpay.de/docs/s
 
 ## 📦 Requirements
 
-The FLIZpay iOS SDK requires Xcode 15 or later and is compatible with apps targeting iOS 13 or above. 
+The FLIZpay iOS SDK requires Xcode 15 or later and is compatible with apps targeting iOS 13 or above.
+
+## 💻 Installation
+
+### Swift Package Manager
+
+Add the following to your `Package.swift` dependencies:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/Flizpay/flizpay-ios.git", from: "0.2.0")
+]
+```
+
+### CocoaPods
+
+Add the following to your `Podfile`:
+
+```ruby
+pod 'FlizpaySDK', '~> 0.2.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
 
 ## ⚡️ Quick Start
 


### PR DESCRIPTION
After merging we need to release to cocoapods 



 ```1. Update the podspec info (version, email, etc.)
  2. Create a git tag matching your version:
  git tag -a 1.0.0 -m "Release 1.0.0"
  git push origin 1.0.0
  3. Register with CocoaPods trunk (first time only):
  pod trunk register carlos.cunha@flizpay.de 'Flizpay' --description='Flizpay SDK'
  4. Validate your podspec:
  pod spec lint
  5. Push to CocoaPods:
  pod trunk push
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added CocoaPods support for the Flizpay iOS SDK, enabling integration via pod installation.
	- Updated package configuration to improve compatibility with specific architectures (x86_64 and arm64) for the SDK.
	- Enhanced documentation with detailed installation instructions for Swift Package Manager and CocoaPods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->