### PR TITLE
feat: update no credentials host for ING bank

### DIFF
--- a/Sources/FlizpaySDK/Lib/WebViewService.swift
+++ b/Sources/FlizpaySDK/Lib/WebViewService.swift
@@ -82,7 +82,7 @@ extension FlizpayWebView: WKNavigationDelegate {
 
     private var noCredentialsBankHosts: [String] {
         return [
-            "ing-diba.de",   // ING-DiBa
+            "myaccount.ing.com",   // ING-DiBa
             "revolut.com",   // Revolut
             "consorsbank.de",// Consorsbank
             "n26.com",       // N26

--- a/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
+++ b/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
@@ -49,6 +49,6 @@ class FlizpaySDKTests: XCTestCase {
             expectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 10.0)
     }
 }


### PR DESCRIPTION
Update no credentials host for ING bank

- this fixes issue of Universal link fails to open app HomeBank ING application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the hostname for ING-DiBa to ensure correct handling of external bank links.  
  - Improved test reliability by extending timeout duration for payment failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->