### PR TITLE
Chore/updated readme for onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,18 @@ dependencies: [
 ### Clone https://github.com/Flizpay/ios-demo
 
 Then clone https://github.com/Flizpay/ios-demo and open it with XCode.
-Ask to be added to the FlizPay GmbH Team (and set the team in XCode)
+Ask to be added to the Apple developer "FlizPay GmbH Team" (and set the team in XCode)
 Make sure to build the project for a simulator, not for MacOS or TVOs
+
+### Update urls to point to tailscale
+
+Update the urls in `Sources/FlizpaySDK/Constants.swift` to point to your local environment (if needed)
+
+### Check that the buisness has needed fields in mongoDB
+
+For the Webview to work, the business item in mongoDB must have this value:
+`integrationType: "App SDK"`
+Otherwise, you will see this error: `'Business is not an SDK integration'`
 
 ### CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Then clone https://github.com/Flizpay/ios-demo and open it with XCode.
 Ask to be added to the Apple developer "FlizPay GmbH Team" (and set the team in XCode)
 Make sure to build the project for a simulator, not for MacOS or TVOs
 
-### Update urls to point to tailscale
+### Update URLs to point to your local environment (development only)
 
-Update the urls in `Sources/FlizpaySDK/Constants.swift` to point to your local environment (if needed)
+For local development, update the URLs in `Sources/FlizpaySDK/Constants.swift` to point to your Tailscale environment. **Do not commit these changes to the repository.**
 
 ### Check that the buisness has needed fields in mongoDB
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ dependencies: [
 ]
 ```
 
+### Clone https://github.com/Flizpay/ios-demo
+
+Then clone https://github.com/Flizpay/ios-demo and open it with XCode.
+Ask to be added to the FlizPay GmbH Team (and set the team in XCode)
+Make sure to build the project for a simulator, not for MacOS or TVOs
+
 ### CocoaPods
 
 Add the following to your `Podfile`:
@@ -51,7 +57,8 @@ pod install
 
 ## ⚡️ Quick Start
 
-After installing the SDK, initiate payments effortlessly by: 
+After installing the SDK, initiate payments effortlessly by:
+
 - authorizing your transaction with the `API_KEY` in your backend to obtain a token
 - use it to load the FLIZPay environment in your application
 
@@ -76,6 +83,7 @@ FlizpaySDK.initiatePayment(
 - **`amount`** (`String`, required): The payment amount.
 - **`metadata`** (`JSONValue, optional): The metadata info
 - **`@closure onFailure `** (`Function`, optional): Block that receives an error param to be called when the webview can't be opened
+
 ---
 
 ## 📖 Detailed Integration Guide
@@ -99,4 +107,3 @@ Need assistance?
 ---
 
 Happy coding! 🚀🎉
-

--- a/Sources/FlizpaySDK/Constants.swift
+++ b/Sources/FlizpaySDK/Constants.swift
@@ -1,4 +1,4 @@
 public class Constants {
-    public static let apiURL: String = "https://api.flizpay.de"
+    public static let apiURL: String = "https://api-staging.flizpay.de"
     public static let baseURL: String = "https://secure.flizpay.de"
 }

--- a/Sources/FlizpaySDK/Constants.swift
+++ b/Sources/FlizpaySDK/Constants.swift
@@ -1,4 +1,9 @@
 public class Constants {
-    public static let apiURL: String = "https://api-staging.flizpay.de"
-    public static let baseURL: String = "https://secure.flizpay.de"
+    // make sure to add your tailscale domain here
+    // public static let apiURL: String = "https://api-staging.flizpay.de"
+    public static let apiURL: String = "https://felixs-macbook-pro.tail0c1e83.ts.net:4440"
+    
+    // make sure to add your tailscale domain here
+    // public static let baseURL: String = "https://secure.flizpay.de"
+    public static let baseURL: String = "https://felixs-macbook-pro.tail0c1e83.ts.net:4442"
 }

--- a/Sources/FlizpaySDK/Constants.swift
+++ b/Sources/FlizpaySDK/Constants.swift
@@ -1,9 +1,5 @@
 public class Constants {
-    // make sure to add your tailscale domain here
-    // public static let apiURL: String = "https://api-staging.flizpay.de"
-    public static let apiURL: String = "https://felixs-macbook-pro.tail0c1e83.ts.net:4440"
-    
-    // make sure to add your tailscale domain here
-    // public static let baseURL: String = "https://secure.flizpay.de"
-    public static let baseURL: String = "https://felixs-macbook-pro.tail0c1e83.ts.net:4442"
+    public static let apiURL: String = "https://api.flizpay.de"
+
+    public static let baseURL: String = "https://secure.flizpay.de"
 }


### PR DESCRIPTION
Updated the readme with a few steps that I encountered while getting this up and running. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enforces that only businesses with an App SDK integration can launch the WebView; others receive a clear error message.

* Documentation
  * Expanded onboarding and environment setup instructions for the iOS demo and simulator targets.
  * Added guidance on configuring local Tailscale endpoints and developer team settings.
  * Clarified Quick Start and error handling (onFailure) notes.

* Chores
  * Updated default network endpoints to a development environment for local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->