### PR TITLE
feat: remove FlizpayConfig and udpate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Make sure the scheme part of `urlScheme` is declared in your app's `Info.plist` 
 - **`amount`** (`String`, required): The payment amount.
 - **`metadata`** (`[String: JSONValue]`, optional): The metadata info
 - **`urlScheme`** (`String`, required): The app callback URL used to return the user to your app after redirect-based bank authorization.
-- **`@closure onFailure `** (`Function`, optional): Block that receives an error param to be called when the webview can't be opened
+- **`@closure onFailure`** (`Function`, optional): Block that receives an error param to be called when the webview can't be opened
 
 ### Redirect-based Bank Flows
 

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ pod install
 
 ## ⚡️ Quick Start
 
-After installing the SDK, initiate payments effortlessly by:
+After installing the SDK, register your app callback URL scheme and initiate payments by:
 
 - authorizing your transaction with the `API_KEY` in your backend to obtain a token
-- use it to load the FLIZPay environment in your application
+- using it to load the FLIZPay environment in your application
 
 ```swift
 import FlizpaySDK
@@ -79,20 +79,28 @@ FlizpaySDK.initiatePayment(
     from: currentViewController,
     token: token,
     amount: userAmount,
-    metadata: metadataInfo
+    metadata: metadataInfo,
+    urlScheme: "myapp://flizpay-return"
 ) { error in
     // Handle any error returned from the SDK.
     print("Payment failed: \(error)")
 }
 ```
 
+Make sure the scheme part of `urlScheme` is declared in your app's `Info.plist` under `CFBundleURLTypes`.
+
 ### Parameters
 
 - **`from`** (`UIViewController`, required): The Presenting View Controller where the webview is going to be attached
 - **`token`** (`String`, required): JWT authentication token obtained from your backend (Check our docs on how to authenticate).
 - **`amount`** (`String`, required): The payment amount.
-- **`metadata`** (`JSONValue, optional): The metadata info
+- **`metadata`** (`[String: JSONValue]`, optional): The metadata info
+- **`urlScheme`** (`String`, required): The app callback URL used to return the user to your app after redirect-based bank authorization.
 - **`@closure onFailure `** (`Function`, optional): Block that receives an error param to be called when the webview can't be opened
+
+### Redirect-based Bank Flows
+
+For redirect-based banks such as Revolut or ING, the SDK forwards `urlScheme` to FLIZpay payer-web so the user can return to your app after authorization in the bank app.
 
 ---
 

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
+
 DERIVED_DATA_PATH=DerivedData
+DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 16,OS=latest}"
+
 xcodebuild test \
   -scheme FlizpaySDK \
-  -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+  -destination "$DESTINATION" \
   -enableCodeCoverage YES \
   -derivedDataPath $DERIVED_DATA_PATH

--- a/Sources/FlizpaySDK/FlizpaySDK.swift
+++ b/Sources/FlizpaySDK/FlizpaySDK.swift
@@ -1,20 +1,5 @@
 import UIKit
 
-/// Configuration for FlizPay SDK URL overrides.
-///
-/// - Parameters:
-///   - apiUrl: Optional override for the API URL (defaults to production if nil or empty)
-///   - baseUrl: Optional override for the base URL (defaults to production if nil or empty)
-public struct FlizpayConfig {
-    public let apiUrl: String?
-    public let baseUrl: String?
-    
-    public init(apiUrl: String? = nil, baseUrl: String? = nil) {
-        self.apiUrl = apiUrl
-        self.baseUrl = baseUrl
-    }
-}
-
 /// The Flizpay SDK class.
 /// This class is the entry point for the SDK.
 /// It provides a method to initiate the payment flow.
@@ -29,7 +14,6 @@ public class FlizpaySDK {
     ///   - amount: The transaction amount.
     ///   - metadata: The metadata object
     ///   - urlScheme: The application url scheme.
-    ///   - config: Optional configuration for URL overrides.
     ///   - transactionService: Inject the transaction service, for mockup purposes
     ///   - onFailure: Optional completion closure if you want to handle errors (e.g., show alerts).
     public static func initiatePayment(
@@ -38,25 +22,17 @@ public class FlizpaySDK {
         amount: String,
         metadata: [String: JSONValue]? = nil,
         urlScheme: String,
-        config: FlizpayConfig? = nil,
         transactionService: TransactionService? = nil,
         onFailure: ((Error) -> Void)? = nil
     ) {
-        let transactionService = transactionService ?? TransactionService(
-            apiUrl: config?.apiUrl,
-            baseUrl: config?.baseUrl
-        )
-        
-        // Use configured base URL or fall back to production default
-        let effectiveBaseUrl = config?.baseUrl?.isEmpty == false ? config!.baseUrl! : Constants.baseURL
-        
+        let transactionService = transactionService ?? TransactionService()
+
         transactionService.fetchTransactionInfo(token: token, amount: amount, metadata: metadata) { result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let transactionResponse):
-                    // Unwrap the redirectUrl or use configured base URL
-                    let redirectUrl = transactionResponse.redirectUrl ?? effectiveBaseUrl
-                    
+                    let redirectUrl = transactionResponse.redirectUrl ?? Constants.baseURL
+
                     // Present the web view
                     FlizpayWebView().present(
                         from: presentingVC,

--- a/Sources/FlizpaySDK/Lib/TransactionService.swift
+++ b/Sources/FlizpaySDK/Lib/TransactionService.swift
@@ -74,13 +74,10 @@ struct TransactionRequest: Encodable {
 public class TransactionService {
     private let urlSession: URLSession
     private let effectiveApiUrl: String
-    private let effectiveBaseUrl: String
 
-    init(apiUrl: String? = nil, baseUrl: String? = nil, urlSession: URLSession = .shared) {
+    init(urlSession: URLSession = .shared) {
         self.urlSession = urlSession
-        // Use provided URLs or fallback to production defaults
-        self.effectiveApiUrl = apiUrl?.isEmpty == false ? apiUrl! : Constants.apiURL
-        self.effectiveBaseUrl = baseUrl?.isEmpty == false ? baseUrl! : Constants.baseURL
+        self.effectiveApiUrl = Constants.apiURL
     }
     
     /// Fetches the transaction info from the FLIZPay backend.

--- a/Sources/FlizpaySDK/Lib/WebViewService.swift
+++ b/Sources/FlizpaySDK/Lib/WebViewService.swift
@@ -30,9 +30,20 @@ public class FlizpayWebView: UIViewController {
     ///   - jwt: The JWT token fetched by the host app.
     public func present(from presentingVC: UIViewController, redirectUrl: String, urlScheme: String, jwt: String) {
         let flizpayWebView = FlizpayWebView()
-        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
-        let encodedUrlScheme = urlScheme.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? urlScheme
-        let redirectUrlWithJwtToken = "\(redirectUrl)&jwt=\(jwt)&redirect-url=\(encodedUrlScheme)"
+        let redirectUrlWithJwtToken: String
+
+        if var components = URLComponents(string: redirectUrl) {
+            var queryItems = components.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "jwt", value: jwt))
+            queryItems.append(URLQueryItem(name: "redirect-url", value: urlScheme))
+            components.queryItems = queryItems
+            redirectUrlWithJwtToken = components.string ?? redirectUrl
+        } else {
+            let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+            let encodedUrlScheme = urlScheme.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? urlScheme
+            let separator = redirectUrl.contains("?") ? "&" : "?"
+            redirectUrlWithJwtToken = "\(redirectUrl)\(separator)jwt=\(jwt)&redirect-url=\(encodedUrlScheme)"
+        }
         
         flizpayWebView.redirectUrl = URL(string: redirectUrlWithJwtToken)
         flizpayWebView.urlScheme = urlScheme
@@ -49,7 +60,9 @@ public class FlizpayWebView: UIViewController {
         wv.translatesAutoresizingMaskIntoConstraints = false
         
         if #available(iOS 16.4, *) {
-              wv.isInspectable = true
+            #if DEBUG
+            wv.isInspectable = true
+            #endif
         }
 
         // Set the navigation delegate to self to intercept deep links

--- a/Sources/FlizpaySDK/Lib/WebViewService.swift
+++ b/Sources/FlizpaySDK/Lib/WebViewService.swift
@@ -30,7 +30,9 @@ public class FlizpayWebView: UIViewController {
     ///   - jwt: The JWT token fetched by the host app.
     public func present(from presentingVC: UIViewController, redirectUrl: String, urlScheme: String, jwt: String) {
         let flizpayWebView = FlizpayWebView()
-        let redirectUrlWithJwtToken = "\(redirectUrl)&jwt=\(jwt)&redirect-url=\(urlScheme)"
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+        let encodedUrlScheme = urlScheme.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? urlScheme
+        let redirectUrlWithJwtToken = "\(redirectUrl)&jwt=\(jwt)&redirect-url=\(encodedUrlScheme)"
         
         flizpayWebView.redirectUrl = URL(string: redirectUrlWithJwtToken)
         flizpayWebView.urlScheme = urlScheme
@@ -45,6 +47,10 @@ public class FlizpayWebView: UIViewController {
 
         let wv = WKWebView(frame: .zero, configuration: config)
         wv.translatesAutoresizingMaskIntoConstraints = false
+        
+        if #available(iOS 16.4, *) {
+              wv.isInspectable = true
+        }
 
         // Set the navigation delegate to self to intercept deep links
         wv.navigationDelegate = self

--- a/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
+++ b/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
@@ -1,9 +1,11 @@
 import XCTest
 @testable import FlizpaySDK
 
-extension String: Error {}
+private enum MockTestError: Error {
+    case invalidToken
+}
 
-private final class PresentingViewControllerSpy: UIViewController {
+final class PresentingViewControllerSpy: UIViewController {
     var presentExpectation: XCTestExpectation?
     var capturedPresentedViewController: UIViewController?
 
@@ -53,7 +55,7 @@ class FlizpaySDKTests: XCTestCase {
     func testInitiatePaymentFailure() {
         // Given
         let expectation = expectation(description: "Payment initiation fails")
-        mockTransactionService.mockResult = .failure("Invalid Token")
+        mockTransactionService.mockResult = .failure(MockTestError.invalidToken)
         
         // When
         FlizpaySDK.initiatePayment(from: mockViewController, token: "invalid-token", amount: "100.00", urlScheme: "flizdemo://test?foo=bar", transactionService: mockTransactionService) { error in

--- a/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
+++ b/Tests/FlizpaySDKTests/FlizpaySDKTests.swift
@@ -3,14 +3,25 @@ import XCTest
 
 extension String: Error {}
 
+private final class PresentingViewControllerSpy: UIViewController {
+    var presentExpectation: XCTestExpectation?
+    var capturedPresentedViewController: UIViewController?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        capturedPresentedViewController = viewControllerToPresent
+        presentExpectation?.fulfill()
+        completion?()
+    }
+}
+
 class FlizpaySDKTests: XCTestCase {
-    var mockViewController: UIViewController!
+    var mockViewController: PresentingViewControllerSpy!
     var mockTransactionService: MockTransactionService!
     var sdk: FlizpaySDK!
     
     override func setUp() {
         super.setUp()
-        mockViewController = UIViewController()
+        mockViewController = PresentingViewControllerSpy()
         mockTransactionService = MockTransactionService()
     }
     
@@ -24,6 +35,7 @@ class FlizpaySDKTests: XCTestCase {
     func testInitiatePaymentSuccess() {
         // Given
         let expectation = expectation(description: "Payment Initiated")
+        mockViewController.presentExpectation = expectation
         
         let mockResponse = try! JSONDecoder().decode(TransactionResponse.self, from: String("{\"data\":{\"redirectUrl\": \"https://example.com\"}}").data(using: String.Encoding.utf8) ?? Data())
         mockTransactionService.mockResult = .success(mockResponse)
@@ -33,8 +45,9 @@ class FlizpaySDKTests: XCTestCase {
             // Then
             XCTAssertNil(error)
         }
-        expectation.fulfill()
+
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(mockViewController.capturedPresentedViewController is FlizpayWebView)
     }
     
     func testInitiatePaymentFailure() {

--- a/Tests/FlizpaySDKTests/WebViewCredentialsBridgeTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewCredentialsBridgeTests.swift
@@ -20,7 +20,7 @@ class WebViewCredentialsBridgeTests: XCTestCase {
         XCTAssertNotNil(script, "JavaScript interface should be injected")
     }
 
-    func testRegisterMessageHandlers() {
+    func testInjectedBridgeScriptContainsExpectedHandlerNames() {
         let injectedScript = webView.configuration.userContentController.userScripts.first?.source
 
         XCTAssertNotNil(injectedScript, "Expected bridge JavaScript to be injected")

--- a/Tests/FlizpaySDKTests/WebViewCredentialsBridgeTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewCredentialsBridgeTests.swift
@@ -21,27 +21,12 @@ class WebViewCredentialsBridgeTests: XCTestCase {
     }
 
     func testRegisterMessageHandlers() {
-        let js = """
-            (() => {
-                return (typeof window.webkit !== 'undefined' &&
-                        typeof window.webkit.messageHandlers !== 'undefined' &&
-                        typeof window.webkit.messageHandlers.saveCredentials !== 'undefined' &&
-                        typeof window.webkit.messageHandlers.getCredentials !== 'undefined' &&
-                        typeof window.webkit.messageHandlers.clearCredentials !== 'undefined');
-            })();
-            """
+        let injectedScript = webView.configuration.userContentController.userScripts.first?.source
 
-            let expectation = XCTestExpectation(description: "Check if handlers are registered")
-
-            webView.evaluateJavaScript(js) { result, error in
-                if let result = result as? Bool {
-                    XCTAssertTrue(result, "Expected message handlers to be registered")
-                } else {
-                    XCTFail("Failed to evaluate JavaScript or handlers are missing")
-                }
-                expectation.fulfill()
-            }
-
-            wait(for: [expectation], timeout: 20.0)
+        XCTAssertNotNil(injectedScript, "Expected bridge JavaScript to be injected")
+        XCTAssertTrue(injectedScript?.contains("saveCredentials") == true)
+        XCTAssertTrue(injectedScript?.contains("getCredentials") == true)
+        XCTAssertTrue(injectedScript?.contains("clearCredentials") == true)
+        XCTAssertTrue(injectedScript?.contains("closeWebView") == true)
     }
 }

--- a/Tests/FlizpaySDKTests/WebViewServiceTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewServiceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import WebKit
 @testable import FlizpaySDK
 
-private final class PresentingViewControllerSpy: UIViewController {
+private final class WebViewPresentingViewControllerSpy: UIViewController {
     var capturedPresentedViewController: UIViewController?
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
@@ -122,7 +122,7 @@ class FlizpayWebViewTests: XCTestCase {
 
     func testPresent_encodesUrlSchemeBeforeAppendingRedirectUrl() {
         // Given
-        let presentingVC = PresentingViewControllerSpy()
+        let presentingVC = WebViewPresentingViewControllerSpy()
         let webView = FlizpayWebView()
 
         // When

--- a/Tests/FlizpaySDKTests/WebViewServiceTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewServiceTests.swift
@@ -136,10 +136,15 @@ class FlizpayWebViewTests: XCTestCase {
         // Then
         let presentedWebView = presentingVC.capturedPresentedViewController as? FlizpayWebView
         XCTAssertNotNil(presentedWebView)
-        XCTAssertEqual(
-            presentedWebView?.redirectUrl?.absoluteString,
-            "https://example.com/checkout?payment=123&jwt=mock-token&redirect-url=flizdemo%3A%2F%2Fpayment-return%3Ffoo%3Dbar"
-        )
+        let components = URLComponents(url: try XCTUnwrap(presentedWebView?.redirectUrl), resolvingAgainstBaseURL: false)
+        let queryItems = try XCTUnwrap(components?.queryItems)
+
+        XCTAssertEqual(components?.scheme, "https")
+        XCTAssertEqual(components?.host, "example.com")
+        XCTAssertEqual(components?.path, "/checkout")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "payment" })?.value, "123")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "jwt" })?.value, "mock-token")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "redirect-url" })?.value, "flizdemo://payment-return?foo=bar")
     }
 
     func testPresent_addsFirstQueryItemsToRedirectUrlWithoutQuery() {
@@ -158,10 +163,14 @@ class FlizpayWebViewTests: XCTestCase {
         // Then
         let presentedWebView = presentingVC.capturedPresentedViewController as? FlizpayWebView
         XCTAssertNotNil(presentedWebView)
-        XCTAssertEqual(
-            presentedWebView?.redirectUrl?.absoluteString,
-            "https://example.com/checkout?jwt=mock-token&redirect-url=flizdemo%3A%2F%2Fpayment-return"
-        )
+        let components = URLComponents(url: try XCTUnwrap(presentedWebView?.redirectUrl), resolvingAgainstBaseURL: false)
+        let queryItems = try XCTUnwrap(components?.queryItems)
+
+        XCTAssertEqual(components?.scheme, "https")
+        XCTAssertEqual(components?.host, "example.com")
+        XCTAssertEqual(components?.path, "/checkout")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "jwt" })?.value, "mock-token")
+        XCTAssertEqual(queryItems.first(where: { $0.name == "redirect-url" })?.value, "flizdemo://payment-return")
     }
     
 }

--- a/Tests/FlizpaySDKTests/WebViewServiceTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewServiceTests.swift
@@ -120,7 +120,7 @@ class FlizpayWebViewTests: XCTestCase {
         XCTAssertTrue(openCalled, "Expected UIApplication.open to be called")
     }
 
-    func testPresent_encodesUrlSchemeBeforeAppendingRedirectUrl() {
+    func testPresent_addsQueryItemsToRedirectUrlThatAlreadyContainsQuery() {
         // Given
         let presentingVC = WebViewPresentingViewControllerSpy()
         let webView = FlizpayWebView()
@@ -139,6 +139,28 @@ class FlizpayWebViewTests: XCTestCase {
         XCTAssertEqual(
             presentedWebView?.redirectUrl?.absoluteString,
             "https://example.com/checkout?payment=123&jwt=mock-token&redirect-url=flizdemo%3A%2F%2Fpayment-return%3Ffoo%3Dbar"
+        )
+    }
+
+    func testPresent_addsFirstQueryItemsToRedirectUrlWithoutQuery() {
+        // Given
+        let presentingVC = WebViewPresentingViewControllerSpy()
+        let webView = FlizpayWebView()
+
+        // When
+        webView.present(
+            from: presentingVC,
+            redirectUrl: "https://example.com/checkout",
+            urlScheme: "flizdemo://payment-return",
+            jwt: "mock-token"
+        )
+
+        // Then
+        let presentedWebView = presentingVC.capturedPresentedViewController as? FlizpayWebView
+        XCTAssertNotNil(presentedWebView)
+        XCTAssertEqual(
+            presentedWebView?.redirectUrl?.absoluteString,
+            "https://example.com/checkout?jwt=mock-token&redirect-url=flizdemo%3A%2F%2Fpayment-return"
         )
     }
     

--- a/Tests/FlizpaySDKTests/WebViewServiceTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewServiceTests.swift
@@ -2,6 +2,15 @@ import XCTest
 import WebKit
 @testable import FlizpaySDK
 
+private final class PresentingViewControllerSpy: UIViewController {
+    var capturedPresentedViewController: UIViewController?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        capturedPresentedViewController = viewControllerToPresent
+        completion?()
+    }
+}
+
 class FlizpayWebViewTests: XCTestCase {
     var sut: FlizpayWebView!
     var mockWebViewBridge: MockWebViewBridge!
@@ -109,6 +118,28 @@ class FlizpayWebViewTests: XCTestCase {
         // Then
         XCTAssertEqual(policy, .cancel, "Should cancel if host is recognized and app can open")
         XCTAssertTrue(openCalled, "Expected UIApplication.open to be called")
+    }
+
+    func testPresent_encodesUrlSchemeBeforeAppendingRedirectUrl() {
+        // Given
+        let presentingVC = PresentingViewControllerSpy()
+        let webView = FlizpayWebView()
+
+        // When
+        webView.present(
+            from: presentingVC,
+            redirectUrl: "https://example.com/checkout?payment=123",
+            urlScheme: "flizdemo://payment-return?foo=bar",
+            jwt: "mock-token"
+        )
+
+        // Then
+        let presentedWebView = presentingVC.capturedPresentedViewController as? FlizpayWebView
+        XCTAssertNotNil(presentedWebView)
+        XCTAssertEqual(
+            presentedWebView?.redirectUrl?.absoluteString,
+            "https://example.com/checkout?payment=123&jwt=mock-token&redirect-url=flizdemo%3A%2F%2Fpayment-return%3Ffoo%3Dbar"
+        )
     }
     
 }

--- a/Tests/FlizpaySDKTests/WebViewServiceTests.swift
+++ b/Tests/FlizpaySDKTests/WebViewServiceTests.swift
@@ -120,7 +120,7 @@ class FlizpayWebViewTests: XCTestCase {
         XCTAssertTrue(openCalled, "Expected UIApplication.open to be called")
     }
 
-    func testPresent_addsQueryItemsToRedirectUrlThatAlreadyContainsQuery() {
+    func testPresent_addsQueryItemsToRedirectUrlThatAlreadyContainsQuery() throws {
         // Given
         let presentingVC = WebViewPresentingViewControllerSpy()
         let webView = FlizpayWebView()
@@ -147,7 +147,7 @@ class FlizpayWebViewTests: XCTestCase {
         XCTAssertEqual(queryItems.first(where: { $0.name == "redirect-url" })?.value, "flizdemo://payment-return?foo=bar")
     }
 
-    func testPresent_addsFirstQueryItemsToRedirectUrlWithoutQuery() {
+    func testPresent_addsFirstQueryItemsToRedirectUrlWithoutQuery() throws {
         // Given
         let presentingVC = WebViewPresentingViewControllerSpy()
         let webView = FlizpayWebView()


### PR DESCRIPTION
# Remove FlizpayConfig and udpate README. Align iOS SDK redirect handling with Android URL scheme contract

## Summary
This PR aligns the iOS SDK and demo app with the updated Android SDK contract for redirect-based payment flows.

## Changes
- removes public URL override support via FlizpayConfig
- keeps urlScheme as the required input for `FlizpaySDK.initiatePayment(...)`
- uses `Constants.baseURL` as the fallback redirect URL
- percent-encodes the redirect-url value before loading payer-web
- updates README examples and parameter docs to reflect the new contract

## Tests

- [x] Rebuilt fresh demo app with udpated ios-sdk package
- [x] Successfully completed TR flow payment with Revolut

## Notion

[NOTION TICKET](https://www.notion.so/feat-android-ios-sdk-to-accept-app-url-scheme-with-initiatePayment-method-Update-docs-3200aa2641a78086b595d43f6aaa630b?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced required URL scheme parameter to enable redirect-based bank payment flows.
  * Updated metadata parameter type for improved flexibility.
  * Enabled WebView inspection for development on iOS 16.4+.

* **Bug Fixes**
  * Ensures the URL scheme is percent-encoded when appended to redirect URLs.

* **Documentation**
  * Updated Quick Start with URL scheme registration and a new "Redirect-based Bank Flows" section.

* **Refactor**
  * Removed public configuration for overriding API/base URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->